### PR TITLE
New color scheme - matching Radiance GTK theme

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,6 +54,10 @@ mc.conf
 -------
  *Henrik Pauli <ralesk(at)drangolin(dot)net>
 
+metallic_bottle.conf
+--------------------
+ *Tomasz Wyderka <wyderkat(at)cofoh(dot)com>
+
 monokai.conf
 ------------
   *Thanh Tran <trongthanh(at)gmail(dot)com>

--- a/colorschemes/metallic_bottle.conf
+++ b/colorschemes/metallic_bottle.conf
@@ -1,0 +1,115 @@
+###
+# Copyright 2013 Tomasz Wyderka <wyderkat(at)cofoh(dot)com>
+##
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+
+[theme_info]
+name=Mettalic Bottle
+description=White background color scheme matching GTK "Radiance" theme. 
+version=1.22.0
+author=Tomasz Wyderka
+url=http://www.cofoh.com/mettalic_bottle
+
+[named_styles]
+
+default=0x000000;0xffffff;false;false
+error=0xffffff;0x843121
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=0x000000;0xC48C65;false;true
+current_line=0x000000;0xF6F4F2;true
+brace_good=0x757C750;xFFFFFF;true;false
+brace_bad=0x843121;0xFFFFFF;true;false
+margin_line_number=0x000000;0xDFD7CF
+margin_folding=0x000000;0xF6F4F2
+fold_symbol_highlight=0xffffff
+indent_guide=0x3D291C
+caret=0x000000;0x000000;false
+marker_line=0x000000;0x1D1613
+marker_search=0x000000;0x843121
+marker_mark=0x000000;0x757C75
+call_tips=0xA1654B;0xffffff;false;false
+white_space=0xA1654B;0xffffff;true;false
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=0x757C75
+comment_doc=0x4B4A3A
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=0x644129
+number_1=number
+number_2=number_1
+
+type=0x843121;;true
+class=type
+function=0x843121
+parameter=function
+
+keyword=0x1D1613;;true
+keyword_1=keyword
+keyword_2=0x3D291C;;true;true
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=0x4B4A3A
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=0x000000;0xe0c0e0
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=0xC48C65
+regex=number_1
+operator=0xD0C096
+decorator=string_1,bold
+other=0xC48C65
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=type
+tag_unknown=tag,bold
+tag_end=tag,bold
+attribute=keyword_1
+attribute_unknown=attribute,bold
+value=string_1
+entity=default
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=0xC48C65
+line_removed=0x843121
+line_changed=preprocessor

--- a/colorschemes/metallic_bottle.conf
+++ b/colorschemes/metallic_bottle.conf
@@ -19,7 +19,7 @@
 
 [theme_info]
 name=Mettalic Bottle
-description=White background color scheme matching GTK "Radiance" theme. 
+description=Bright color scheme matching GTK "Radiance" theme. 
 version=1.22.0
 author=Tomasz Wyderka
 url=http://www.cofoh.com/mettalic_bottle
@@ -27,20 +27,20 @@ url=http://www.cofoh.com/mettalic_bottle
 [named_styles]
 
 default=0x000000;0xFBFAF9;false;false
-error=0xffffff;0x843121
+error=0xffffff;0x843121;false;true
 
 # Editor styles
 #-------------------------------------------------------------------------------
 
 selection=0x000000;0xC48C65;false;true
 current_line=0x000000;0xFFFFFF;true
-brace_good=0x757C750;xFFFFFF;true;false
-brace_bad=0x843121;0xFFFFFF;true;false
+brace_good=0x757C75;;true;false
+brace_bad=0x843121;;true;false
 margin_line_number=0x000000;0xDFD7CF
 margin_folding=0x000000;0xF6F4F2
 fold_symbol_highlight=0xffffff
 indent_guide=0x3D291C
-caret=0x000000;0x000000;false
+caret=0x843121
 marker_line=0x000000;0x1D1613
 marker_search=0x000000;0x843121
 marker_mark=0x000000;0x757C75
@@ -112,4 +112,4 @@ entity=default
 
 line_added=0xC48C65
 line_removed=0x843121
-line_changed=preprocessor
+line_changed=0xFBFAF9

--- a/colorschemes/metallic_bottle.conf
+++ b/colorschemes/metallic_bottle.conf
@@ -26,14 +26,14 @@ url=http://www.cofoh.com/mettalic_bottle
 
 [named_styles]
 
-default=0x000000;0xffffff;false;false
+default=0x000000;0xFBFAF9;false;false
 error=0xffffff;0x843121
 
 # Editor styles
 #-------------------------------------------------------------------------------
 
 selection=0x000000;0xC48C65;false;true
-current_line=0x000000;0xFBFAF9;true
+current_line=0x000000;0xFFFFFF;true
 brace_good=0x757C750;xFFFFFF;true;false
 brace_bad=0x843121;0xFFFFFF;true;false
 margin_line_number=0x000000;0xDFD7CF

--- a/colorschemes/metallic_bottle.conf
+++ b/colorschemes/metallic_bottle.conf
@@ -33,7 +33,7 @@ error=0xffffff;0x843121
 #-------------------------------------------------------------------------------
 
 selection=0x000000;0xC48C65;false;true
-current_line=0x000000;0xF6F4F2;true
+current_line=0x000000;0xFBFAF9;true
 brace_good=0x757C750;xFFFFFF;true;false
 brace_bad=0x843121;0xFFFFFF;true;false
 margin_line_number=0x000000;0xDFD7CF

--- a/colorschemes/metallic_bottle.conf
+++ b/colorschemes/metallic_bottle.conf
@@ -50,8 +50,8 @@ white_space=0xA1654B;0xffffff;true;false
 # Programming languages
 #-------------------------------------------------------------------------------
 
-comment=0x757C75
-comment_doc=0x4B4A3A
+comment=0x757C75;;false;true
+comment_doc=0x4B4A3A;;false;true
 comment_line=comment
 comment_line_doc=comment_doc
 comment_doc_keyword=comment_doc,bold

--- a/index/index.conf
+++ b/index/index.conf
@@ -71,7 +71,7 @@ version=1.22.1
 
 [metallic_bottle]
 name=Mettalic Bottle
-desc=White background color scheme matching GTK "Radiance" theme.
+desc=Bright color scheme matching GTK "Radiance" theme.
 repos=default
 version=1.22.0
 

--- a/index/index.conf
+++ b/index/index.conf
@@ -69,6 +69,12 @@ desc=Midnight Commander-like scheme
 repos=default
 version=1.22.1
 
+[metallic_bottle]
+name=Mettalic Bottle
+desc=White background color scheme matching GTK "Radiance" theme.
+repos=default
+version=1.22.0
+
 [monokai]
 name=Monokai
 desc=It's warm, colorful and pleasing to the eyes

--- a/index/index.json
+++ b/index/index.json
@@ -62,7 +62,7 @@
     },
     "metallic_bottle": {
       "name": "Mettalic Bottle",
-      "desc": "White background color scheme matching GTK "Radiance" theme.",
+      "desc": "Bright color scheme matching GTK "Radiance" theme.",
       "repos": ["default"],
       "version": "1.22.0"
     },

--- a/index/index.json
+++ b/index/index.json
@@ -60,6 +60,12 @@
       "repos": ["default"],
       "version": "1.22.1"
     },
+    "metallic_bottle": {
+      "name": "Mettalic Bottle",
+      "desc": "White background color scheme matching GTK "Radiance" theme.",
+      "repos": ["default"],
+      "version": "1.22.0"
+    },
     "monokai": {
       "name": "Monokai",
       "desc": "It's warm, colorful and pleasing to the eyes",

--- a/index/index.xml
+++ b/index/index.xml
@@ -81,7 +81,7 @@
     </theme>
     <theme id="metallic_bottle">
       <name>Mettalic Bottle</name>
-      <desc>White background color scheme matching GTK "Radiance" theme.</desc>
+      <desc>Bright color scheme matching GTK "Radiance" theme.</desc>
       <repos>
         <repo>default</repo>
       </repos>

--- a/index/index.xml
+++ b/index/index.xml
@@ -79,6 +79,14 @@
       </repos>
       <version>1.22.1</version>
     </theme>
+    <theme id="metallic_bottle">
+      <name>Mettalic Bottle</name>
+      <desc>White background color scheme matching GTK "Radiance" theme.</desc>
+      <repos>
+        <repo>default</repo>
+      </repos>
+      <version>1.22.0</version>
+    </theme>
     <theme id="monokai">
       <name>Monokai</name>
       <desc>It's warm, colorful and pleasing to the eyes</desc>


### PR DESCRIPTION
Hi, 
I've created Metallic Bottle colorscheme. 
Geany has just few white background colorschemes.
Maybe mine will be useful.

I haven't add screenshot because it looks like you autogenerate them.
Anyway, it would be beneficent to show also some part of window and resemblance with GTK theme. Here is my screen shot:
http://www.cofoh.com/metallic_bottle

Cheers

