### PR TITLE
Allow install script to be invoked anywhere

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
+SCRIPTDIR=$(dirname $(readlink -f "$0"))
 CSDIR="$HOME/.config/geany/colorschemes/"
 echo "Installing themes into \`$CSDIR'..."
 mkdir -p "$CSDIR"
-for SCHEME in `ls colorschemes/*.conf`
+for SCHEME in `ls ${SCRIPTDIR}/colorschemes/*.conf`
 do
   BNAME=`basename "$SCHEME"`
   echo " => $BNAME"


### PR DESCRIPTION
Prior to this change, invoking the install script when the current directory is not at the repository root results in a failure to install.