### PR TITLE
use XDG_CONFIG_HOME if available

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
-CSDIR="$HOME/.config/geany/colorschemes/"
-echo "Installing themes into \`$CSDIR'..."
+
+CSDIR="${XDG_CONFIG_HOME:-$HOME/.config}/geany/colorschemes/"
+echo "Installing themes into '$CSDIR'..."
 mkdir -p "$CSDIR"
 for SCHEME in `ls colorschemes/*.conf`
 do

--- a/install.sh
+++ b/install.sh
@@ -3,9 +3,9 @@
 CSDIR="${XDG_CONFIG_HOME:-$HOME/.config}/geany/colorschemes/"
 echo "Installing themes into '$CSDIR'..."
 mkdir -p "$CSDIR"
-for SCHEME in `ls colorschemes/*.conf`
-do
-  BNAME=`basename "$SCHEME"`
+
+for SCHEME in colorschemes/*.conf; do
+  BNAME="${SCHEME##*/}"
   echo " => $BNAME"
   cp "$SCHEME" "$CSDIR"
 done


### PR DESCRIPTION
per title, also replaced fragile `ls` with a more robust copy loop